### PR TITLE
feat: enhance ProfessorCard styling for improved layout and readability

### DIFF
--- a/frontend/src/pages/ProfessorCatalog.css
+++ b/frontend/src/pages/ProfessorCatalog.css
@@ -875,6 +875,18 @@
   .catalog-page .prof-name {
     font-size: 0.84rem;
   }
+
+  .prof-card-info {
+    padding: 10px 12px;
+  }
+
+  .prof-card-footer {
+    margin-top: 6px;
+  }
+
+  .prof-rating-count {
+    font-size: 0.56rem;
+  }
 }
 
 /* ─── PROFESSOR CARD ───────────────────────────────────────── */
@@ -1011,19 +1023,22 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  position: relative;
+  gap: 2px;
   margin-top: 4px;
 }
 
 .prof-rating-count {
   font-size: 0.6rem;
   color: #bbb;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .prof-rating-count--center {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  text-align: center;
 }
 
 .prof-sub-ratings {
@@ -1349,6 +1364,28 @@
 
   .prof-card-photo {
     height: 120px;
+  }
+
+  .prof-card-info {
+    padding: 10px;
+    gap: 4px;
+  }
+
+  .prof-sub-ratings {
+    gap: 4px;
+    margin-top: 4px;
+  }
+
+  .sub-rating-item {
+    padding: 4px 2px;
+  }
+
+  .prof-card-footer {
+    margin-top: 6px;
+  }
+
+  .prof-rating-count {
+    font-size: 0.55rem;
   }
 
   .catalog-list .prof-list-item {


### PR DESCRIPTION
This pull request makes several improvements to the styling of professor cards in the `ProfessorCatalog` page, focusing on layout consistency, spacing, and text overflow handling for better UI clarity and responsiveness.

**Professor card layout and spacing improvements:**
* Added new classes (`prof-card-info`, `prof-card-footer`) and adjusted their padding and margin to improve card structure and spacing. [[1]](diffhunk://#diff-19f674a76497855736f6134bac1933f2ee5b0cf67185928f4e1f6672ed6893d3R878-R889) [[2]](diffhunk://#diff-19f674a76497855736f6134bac1933f2ee5b0cf67185928f4e1f6672ed6893d3R1369-R1390)
* Updated `.prof-sub-ratings` and `.sub-rating-item` to include consistent gaps and padding for better visual separation.

**Rating count display enhancements:**
* Improved `.prof-rating-count` styling to handle long text with ellipsis, set minimum width, and ensure proper alignment and overflow handling.
* Changed `.prof-rating-count--center` to use text alignment instead of absolute positioning for more robust centering.

**Responsive adjustments:**
* Modified padding, gap, and font sizes for various elements to support different screen sizes and maintain visual consistency. [[1]](diffhunk://#diff-19f674a76497855736f6134bac1933f2ee5b0cf67185928f4e1f6672ed6893d3R1369-R1390) [[2]](diffhunk://#diff-19f674a76497855736f6134bac1933f2ee5b0cf67185928f4e1f6672ed6893d3R878-R889)