### PR TITLE
fix: update course display logic to handle rating data absence

### DIFF
--- a/frontend/src/pages/Courses.tsx
+++ b/frontend/src/pages/Courses.tsx
@@ -430,7 +430,8 @@ export default function Courses() {
 					</div>
 
 					<p className="catalog-disclaimer">
-						Course cards currently use TRACE aggregate data only.
+						Courses without any rating data are not shown.{' '}
+						<span>They may still have a page if found via search.</span>
 					</p>
 
 					{loading ? (
@@ -439,7 +440,7 @@ export default function Courses() {
 								<div key={i} className="prof-card skeleton" />
 							))}
 						</div>
-					) : courses.length === 0 ? (
+					) : courses.filter((c) => c.avgRating != null).length === 0 ? (
 						<div className="catalog-empty">
 							<p>No courses match your filters.</p>
 							<button className="clear-btn prominent" onClick={clearFilters}>
@@ -448,7 +449,7 @@ export default function Courses() {
 						</div>
 					) : (
 						<div className="catalog-grid" ref={gridRef}>
-							{courses.map((course) => (
+							{courses.filter((c) => c.avgRating != null).map((course) => (
 								<div
 									key={course.code}
 									className="prof-card course-card"


### PR DESCRIPTION
This pull request updates the course catalog page to only display courses that have rating data available, improving clarity for users. It also updates the disclaimer to reflect this new behavior and ensures the empty state messaging is accurate.

**Catalog display improvements:**

* The course catalog now filters out and hides courses that do not have any rating data (`avgRating` is `null`), so users only see rated courses in the main catalog grid.
* The empty state ("No courses match your filters") now appears only if no courses with rating data match the filters, rather than if no courses at all match.

**User messaging updates:**

* The disclaimer text has been updated to clarify that courses without any rating data are not shown in the catalog, but may still be accessible via search.