### PR TITLE
fix courses and professor catalog

### DIFF
--- a/frontend/src/pages/Courses.tsx
+++ b/frontend/src/pages/Courses.tsx
@@ -108,6 +108,7 @@ export default function Courses() {
 	const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const [numCols, setNumCols] = useState(4);
+	const [isMeasured, setIsMeasured] = useState(false);
 	const gridObserverRef = useRef<ResizeObserver | null>(null);
 	const gridRef = useCallback((node: HTMLDivElement | null) => {
 		if (gridObserverRef.current) {
@@ -118,6 +119,7 @@ export default function Courses() {
 		const update = () => {
 			const cols = window.getComputedStyle(node).gridTemplateColumns.split(' ').length;
 			setNumCols(cols);
+			setIsMeasured(true);
 		};
 		gridObserverRef.current = new ResizeObserver(update);
 		gridObserverRef.current.observe(node);
@@ -132,11 +134,12 @@ export default function Courses() {
 	}, []);
 
 	useEffect(() => {
+		if (!isMeasured) return;
 		setLoading(true);
 		fetchCoursesCatalog({
 			q: filters.q || undefined,
 			dept: filters.dept || undefined,
-			minRating: filters.minRating > 0 ? filters.minRating : undefined,
+			minRating: Math.max(filters.minRating, 0.01),
 			maxRating: filters.maxRating < 5 ? filters.maxRating : undefined,
 			sort: filters.sort,
 			page: filters.page,
@@ -149,7 +152,7 @@ export default function Courses() {
 			})
 			.catch(console.error)
 			.finally(() => setLoading(false));
-	}, [filters, pageSize]);
+	}, [filters, pageSize, isMeasured]);
 
 	useEffect(() => {
 		const next = buildSearchParamsFromFilters(filters);

--- a/frontend/src/pages/ProfessorCatalog.tsx
+++ b/frontend/src/pages/ProfessorCatalog.tsx
@@ -156,6 +156,7 @@ export default function ProfessorCatalog() {
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [numCols, setNumCols] = useState(4);
+  const [isMeasured, setIsMeasured] = useState(false);
   const gridObserverRef = useRef<ResizeObserver | null>(null);
   const gridRef = useCallback((node: HTMLDivElement | null) => {
     if (gridObserverRef.current) {
@@ -166,6 +167,7 @@ export default function ProfessorCatalog() {
     const update = () => {
       const cols = window.getComputedStyle(node).gridTemplateColumns.split(' ').length;
       setNumCols(cols);
+      setIsMeasured(true);
     };
     gridObserverRef.current = new ResizeObserver(update);
     gridObserverRef.current.observe(node);
@@ -190,6 +192,7 @@ export default function ProfessorCatalog() {
 
   // Fetch professors when any filter changes
   useEffect(() => {
+    if (viewMode === 'grid' && !isMeasured) return;
     setLoading(true);
     fetchProfessorsCatalog({
       q:          filters.q          || undefined,
@@ -210,7 +213,7 @@ export default function ProfessorCatalog() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [filters, pageSize]);
+  }, [filters, pageSize, isMeasured, viewMode]);
 
   // Keep filters in the URL so the catalog view is shareable/bookmarkable.
   useEffect(() => {


### PR DESCRIPTION
This pull request improves how the grid layout is measured before fetching data in both the `Courses` and `ProfessorCatalog` pages. The main change is to ensure that the number of columns in the grid is determined before making API requests, preventing layout-dependent issues and unnecessary fetches. Additionally, it tweaks the minimum rating filter logic for courses.

**Grid measurement and data fetching improvements:**

* Added an `isMeasured` state in both `Courses` (`Courses.tsx`) and `ProfessorCatalog` (`ProfessorCatalog.tsx`) to ensure the grid layout is measured before fetching data, preventing fetches until the grid columns are known. [[1]](diffhunk://#diff-15661223de40266e53adf0c25f23dcbc49c2851ef0b849e372c73efbebe2a2abR111) [[2]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759R159)
* Updated the grid observer callbacks to set `isMeasured` to `true` after measuring columns, triggering data fetches only when ready. [[1]](diffhunk://#diff-15661223de40266e53adf0c25f23dcbc49c2851ef0b849e372c73efbebe2a2abR122) [[2]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759R170)
* Modified the data-fetching `useEffect` hooks to early return if the grid is not yet measured, and included `isMeasured` in their dependency arrays to trigger fetches at the right time. Also added `viewMode` as a dependency in `ProfessorCatalog`. [[1]](diffhunk://#diff-15661223de40266e53adf0c25f23dcbc49c2851ef0b849e372c73efbebe2a2abR137-R142) [[2]](diffhunk://#diff-15661223de40266e53adf0c25f23dcbc49c2851ef0b849e372c73efbebe2a2abL152-R155) [[3]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759R195) [[4]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759L213-R216)

**Filter logic improvements:**

* Changed the minimum rating logic in `Courses.tsx` to use `Math.max(filters.minRating, 0.01)` instead of filtering out zero, ensuring a sensible lower bound for ratings.