### PR TITLE
fix scrolling in department and college dropdowns in filter

### DIFF
--- a/frontend/src/pages/Courses.tsx
+++ b/frontend/src/pages/Courses.tsx
@@ -591,7 +591,10 @@ function DepartmentFilter({
 		const handler = (e: MouseEvent) => {
 			if (ref.current && !ref.current.contains(e.target as Node)) toggle(false);
 		};
-		const scrollHandler = () => toggle(false);
+		const scrollHandler = (e: Event) => {
+			if (ref.current && ref.current.contains(e.target as Node)) return;
+			toggle(false);
+		};
 		const closeHandler = () => toggle(false);
 		document.addEventListener('mousedown', handler);
 		document.addEventListener('scroll', scrollHandler, { capture: true, passive: true });

--- a/frontend/src/pages/ProfessorCatalog.tsx
+++ b/frontend/src/pages/ProfessorCatalog.tsx
@@ -922,7 +922,10 @@ function CollegeFilter({
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) toggle(false);
     };
-    const scrollHandler = () => toggle(false);
+    const scrollHandler = (e: Event) => {
+      if (ref.current && ref.current.contains(e.target as Node)) return;
+      toggle(false);
+    };
     const closeHandler = () => toggle(false);
     document.addEventListener('mousedown', handler);
     document.addEventListener('scroll', scrollHandler, { capture: true, passive: true });
@@ -1033,7 +1036,10 @@ function DepartmentFilter({
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) toggle(false);
     };
-    const scrollHandler = () => toggle(false);
+    const scrollHandler = (e: Event) => {
+      if (ref.current && ref.current.contains(e.target as Node)) return;
+      toggle(false);
+    };
     const closeHandler = () => toggle(false);
     document.addEventListener('mousedown', handler);
     document.addEventListener('scroll', scrollHandler, { capture: true, passive: true });


### PR DESCRIPTION
This pull request improves the behavior of dropdown filters in both the Courses and Professor Catalog pages by refining how dropdowns close when the page is scrolled. Previously, dropdowns would close on any scroll event, even if the scroll originated from within the dropdown itself. The updated logic ensures that dropdowns only close when the scroll event happens outside the dropdown, providing a better user experience.

Improvements to dropdown filter behavior:

* Updated the `scrollHandler` in `DepartmentFilter` within `frontend/src/pages/Courses.tsx` to only close the dropdown if the scroll event target is outside the dropdown element.
* Updated the `scrollHandler` in both `CollegeFilter` and `DepartmentFilter` within `frontend/src/pages/ProfessorCatalog.tsx` to use the same improved logic, preventing dropdowns from closing when scrolling inside them. [[1]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759L925-R928) [[2]](diffhunk://#diff-153616c1651e4c53b2f3268035d85ce5f19b63e5fe9843690b047a7c18b50759L1036-R1042)