### PR TITLE
fix: clarify feedback form submission process in Terms & Conditions

### DIFF
--- a/frontend/src/pages/Terms.tsx
+++ b/frontend/src/pages/Terms.tsx
@@ -94,9 +94,10 @@ const Terms = () => {
               <h2>5. Feedback Form</h2>
               <p>
                 RateMyHusky includes a feedback form that accepts a message type, description,
-                and an optional email address. At this time, submissions from this form are
-                not transmitted to or stored on our servers. If this changes, these Terms will
-                be updated accordingly.
+                and an optional email address. Submissions from this form are transmitted to
+                the RateMyHusky team via email and are not stored in our database. Submitted
+                information is used solely to improve the service and will not be shared with
+                third parties.
               </p>
             </section>
 


### PR DESCRIPTION
This pull request updates the Terms of Service to clarify how feedback form submissions are handled. The new language specifies that feedback is sent to the team via email and not stored in the database, and that the information is only used to improve the service.

Terms of Service update:

* Updated the feedback form section in `Terms.tsx` to state that submissions are transmitted to the team via email, not stored in the database, and not shared with third parties.