### PR TITLE
add tip in prof page

### DIFF
--- a/frontend/src/pages/Professor.css
+++ b/frontend/src/pages/Professor.css
@@ -1147,23 +1147,59 @@
   }
 }
 /* ── Course filter tip ── */
+.prof-course-tip-wrapper {
+  padding: 28px clamp(16px, 3vw, 48px) 0;
+}
+
 .prof-course-tip {
   display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  background: #fff;
+  border-radius: 16px;
+  border-left: 4px solid #d6394c;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.06);
+  padding: 18px 20px 18px 22px;
+  font-family: 'Nunito', sans-serif;
+}
+
+.prof-course-tip-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #fef0f0;
+  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  background: color-mix(in srgb, var(--accent, #6c8ebf) 10%, var(--bg-secondary, #1e1e2e));
-  border: 1px solid color-mix(in srgb, var(--accent, #6c8ebf) 30%, transparent);
-  border-radius: 10px;
-  padding: 10px 14px;
-  margin-bottom: 16px;
-  font-size: 0.83rem;
-  color: var(--text-secondary, #a0a0b0);
+  justify-content: center;
+  color: #d6394c;
+  margin-top: 1px;
+}
+
+.prof-course-tip-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.prof-course-tip-label {
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: #d6394c;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 5px;
+}
+
+.prof-course-tip-text {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #555;
+  line-height: 1.55;
 }
 
 .prof-course-tip-text strong {
-  color: var(--text-primary, #e0e0f0);
-  font-weight: 600;
+  color: #333;
+  font-weight: 800;
 }
 
 .prof-course-tip-close {
@@ -1171,15 +1207,48 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-secondary, #a0a0b0);
-  padding: 2px;
+  color: #bbb;
+  padding: 4px;
   display: flex;
   align-items: center;
-  border-radius: 4px;
+  border-radius: 6px;
   transition: color 0.15s, background 0.15s;
+  margin-top: 1px;
 }
 
 .prof-course-tip-close:hover {
-  color: var(--text-primary, #e0e0f0);
-  background: color-mix(in srgb, var(--accent, #6c8ebf) 15%, transparent);
+  color: #888;
+  background: #f0f0f0;
+}
+
+.dark .prof-course-tip {
+  background: #242424;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+  border-left-color: #d6394c;
+}
+
+.dark .prof-course-tip-icon {
+  background: #3a2020;
+  color: #e06070;
+}
+
+.dark .prof-course-tip-label {
+  color: #e06070;
+}
+
+.dark .prof-course-tip-text {
+  color: #aaa;
+}
+
+.dark .prof-course-tip-text strong {
+  color: #e0e0e0;
+}
+
+.dark .prof-course-tip-close {
+  color: #555;
+}
+
+.dark .prof-course-tip-close:hover {
+  color: #aaa;
+  background: #333;
 }

--- a/frontend/src/pages/Professor.css
+++ b/frontend/src/pages/Professor.css
@@ -1146,3 +1146,40 @@
     align-items: center;
   }
 }
+/* ── Course filter tip ── */
+.prof-course-tip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: color-mix(in srgb, var(--accent, #6c8ebf) 10%, var(--bg-secondary, #1e1e2e));
+  border: 1px solid color-mix(in srgb, var(--accent, #6c8ebf) 30%, transparent);
+  border-radius: 10px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-size: 0.83rem;
+  color: var(--text-secondary, #a0a0b0);
+}
+
+.prof-course-tip-text strong {
+  color: var(--text-primary, #e0e0f0);
+  font-weight: 600;
+}
+
+.prof-course-tip-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary, #a0a0b0);
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.prof-course-tip-close:hover {
+  color: var(--text-primary, #e0e0f0);
+  background: color-mix(in srgb, var(--accent, #6c8ebf) 15%, transparent);
+}

--- a/frontend/src/pages/Professor.css
+++ b/frontend/src/pages/Professor.css
@@ -1213,7 +1213,7 @@
   align-items: center;
   border-radius: 6px;
   transition: color 0.15s, background 0.15s;
-  margin-top: 1px;
+  align-self: center;
 }
 
 .prof-course-tip-close:hover {

--- a/frontend/src/pages/Professor.css
+++ b/frontend/src/pages/Professor.css
@@ -1133,7 +1133,7 @@
 @media (max-width: 600px) {
   .prof-radar-section {
     padding: 20px 16px 18px;
-    margin: 0 12px 20px;
+    margin: 20px 12px 20px;
   }
   .prof-radar-legend-labels {
     grid-template-columns: 1fr 1fr;

--- a/frontend/src/pages/Professor.css
+++ b/frontend/src/pages/Professor.css
@@ -1151,6 +1151,17 @@
   padding: 28px clamp(16px, 3vw, 48px) 0;
 }
 
+@media (max-width: 768px) {
+  .prof-course-tip-wrapper {
+    padding: 24px 20px 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .prof-course-tip-wrapper {
+    padding: 20px 16px 0;
+  }
+}
 .prof-course-tip {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -1313,7 +1313,7 @@ const Professor = () => {
             <div className="prof-course-tip-body">
               <div className="prof-course-tip-label">Tip</div>
               <p className="prof-course-tip-text">
-                Want to see ratings and reviews for a specific course? Click <strong>Clear All</strong> above to deselect everything, then click on the course you're interested in. The ratings and reviews will update to show only feedback from students who took that course with this professor.
+                To filter reviews by course, click <strong>Clear All</strong> in the Courses Taught section, then select the course you want to see reviews for.
               </p>
             </div>
             <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -237,6 +237,7 @@ const Professor = () => {
   const MAX_VISIBLE_TERMS = 3;
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
   const [deptAvg, setDeptAvg] = useState<TraceDeptAvgItem[]>([]);
+  const [showCourseTip, setShowCourseTip] = useState(true);
 
   /* ── review pill ── */
   const updateReviewPill = useCallback(() => {
@@ -1298,6 +1299,20 @@ const Professor = () => {
           </section>
         );
       })()}
+
+      {showCourseTip && (
+        <div className="prof-course-tip">
+          <span className="prof-course-tip-text">
+            <strong>Tip:</strong> Clear all courses and click on a specific course to filter reviews by that course.
+          </span>
+          <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      )}
 
       <section className="prof-section prof-reviews-section" ref={reviewsRef}>
         <div className="prof-reviews-header">

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -237,7 +237,7 @@ const Professor = () => {
   const MAX_VISIBLE_TERMS = 3;
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
   const [deptAvg, setDeptAvg] = useState<TraceDeptAvgItem[]>([]);
-  const [showCourseTip, setShowCourseTip] = useState(true);
+  const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('prof_course_tip_dismissed') !== '1');
 
   /* ── review pill ── */
   const updateReviewPill = useCallback(() => {
@@ -1316,7 +1316,7 @@ const Professor = () => {
                 To filter reviews by course, click <strong>Clear All</strong> in the Courses Taught section, then select the course you want to see reviews for.
               </p>
             </div>
-            <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">
+            <button className="prof-course-tip-close" onClick={() => { localStorage.setItem('prof_course_tip_dismissed', '1'); setShowCourseTip(false); }} aria-label="Dismiss tip">
               <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -1301,16 +1301,28 @@ const Professor = () => {
       })()}
 
       {showCourseTip && (
-        <div className="prof-course-tip">
-          <span className="prof-course-tip-text">
-            <strong>Tip:</strong> Clear all courses and click on a specific course to filter reviews by that course.
-          </span>
-          <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+        <div className="prof-course-tip-wrapper">
+          <div className="prof-course-tip">
+            <div className="prof-course-tip-icon">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+            </div>
+            <div className="prof-course-tip-body">
+              <div className="prof-course-tip-label">Tip</div>
+              <p className="prof-course-tip-text">
+                Want to see ratings and reviews for a specific course? Click <strong>Clear All</strong> above to deselect everything, then click on the course you're interested in. The ratings and reviews will update to show only feedback from students who took that course with this professor.
+              </p>
+            </div>
+            <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -1317,7 +1317,7 @@ const Professor = () => {
               </p>
             </div>
             <button className="prof-course-tip-close" onClick={() => setShowCourseTip(false)} aria-label="Dismiss tip">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />
               </svg>

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -1300,7 +1300,7 @@ const Professor = () => {
         );
       })()}
 
-      {showCourseTip && (
+      {showCourseTip && allCourseCodes.length > 0 && (
         <div className="prof-course-tip-wrapper">
           <div className="prof-course-tip">
             <div className="prof-course-tip-icon">


### PR DESCRIPTION
This pull request adds a dismissible tip to the Professor page to help users filter reviews by course. It introduces new UI elements and supporting state logic, along with corresponding CSS for both light and dark themes. There is also a minor adjustment to the radar section margin on mobile.

**New course filter tip feature:**

* Added a dismissible tip UI (`prof-course-tip`) to the Professor page, explaining how to filter reviews by course. The tip appears based on localStorage and can be closed by the user. (`frontend/src/pages/Professor.tsx` [[1]](diffhunk://#diff-855a02caae20052f7d3259fc502ca86898911d15b75d81a958e75cedd5370647R240) [[2]](diffhunk://#diff-855a02caae20052f7d3259fc502ca86898911d15b75d81a958e75cedd5370647R1303-R1328)
* Implemented a new state variable `showCourseTip` to control the tip's visibility and persist dismissal in localStorage. (`frontend/src/pages/Professor.tsx` [frontend/src/pages/Professor.tsxR240](diffhunk://#diff-855a02caae20052f7d3259fc502ca86898911d15b75d81a958e75cedd5370647R240))

**Styling and theming:**

* Added comprehensive CSS for the new tip, including layout, colors, and dark mode support. (`frontend/src/pages/Professor.css` [frontend/src/pages/Professor.cssR1149-R1254](diffhunk://#diff-15afa338eea425b4513f3091fd2fc9536cac62ac6b310ed3d481182e3bbfe7e4R1149-R1254))

**Minor UI adjustment:**

* Adjusted the mobile margin for the radar section for improved spacing. (`frontend/src/pages/Professor.css` [frontend/src/pages/Professor.cssL1136-R1136](diffhunk://#diff-15afa338eea425b4513f3091fd2fc9536cac62ac6b310ed3d481182e3bbfe7e4L1136-R1136))