### PR TITLE
fix maintenance page

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,5 +1,6 @@
 {
   "routes": [
+    { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]
 }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,6 +1,5 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }
-

--- a/maintenance.py
+++ b/maintenance.py
@@ -23,9 +23,9 @@ def set_routing(on: bool):
     with open(VERCEL_JSON) as f:
         data = json.load(f)
     dest = "/maintenance.html" if on else "/index.html"
-    for rw in data.get("rewrites", []):
-        if rw.get("source") == "/(.*)":
-            rw["destination"] = dest
+    for route in data.get("routes", []):
+        if route.get("src") == "/(.*)":
+            route["dest"] = dest
     with open(VERCEL_JSON, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")


### PR DESCRIPTION
This pull request updates the routing configuration for the frontend and aligns the related backend logic to match the new structure. The main change is migrating from the deprecated `rewrites` field to the `routes` field in the Vercel configuration, and updating the code that manages this configuration accordingly.

Routing configuration update:

* In `frontend/vercel.json`, replaced the `rewrites` array with a `routes` array, updating the field names from `source`/`destination` to `src`/`dest` to match Vercel's latest configuration format.

Backend logic alignment:

* In `maintenance.py`, updated the `set_routing` function to modify the `routes` field and the `src`/`dest` keys instead of the deprecated `rewrites` field and `source`/`destination` keys, ensuring compatibility with the new configuration.