### PR TITLE
Fix bugs and improve display for ratings and comments

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn server:app --bind 0.0.0.0:$PORT --preload --workers 1 --threads 8
+web: gunicorn server:app --bind 0.0.0.0:$PORT --preload --workers 1 --threads 8 --limit-request-line 8190

--- a/backend/precompute.py
+++ b/backend/precompute.py
@@ -390,6 +390,27 @@ def main():
     )
     rmp_profs["avg_rating"] = rmp_profs["avg_rating"].where(rmp_profs["avg_rating"].notna(), other=None)
 
+    # ── Comment counts per name_key ──
+    # RMP comments
+    rmp_rev = rmp_reviews[rmp_reviews["comment"].notna() & (rmp_reviews["comment"].astype(str).str.strip() != "")].copy()
+    rmp_rev["_name_key"] = rmp_rev["professor_name"].apply(normalize_name).replace(ALIAS_MAP)
+    rmp_comment_counts = rmp_rev.groupby("_name_key").size()
+
+    # TRACE comments
+    tc_id_cols = tc[["course_id", "instructor_id", "term_id", "name_key"]].drop_duplicates()
+    tcomments_parsed = tcomments[tcomments["comment"].notna() & (tcomments["comment"].astype(str).str.strip() != "")].copy()
+    tcomments_parsed[["_cid", "_iid", "_tid"]] = tcomments_parsed["course_url"].str.extractall(r"sp=(\d+)").unstack().droplevel(0, axis=1)[[0, 1, 2]].astype(float)
+    tcomments_parsed = tcomments_parsed.dropna(subset=["_cid", "_iid", "_tid"])
+    tcomments_parsed[["_cid", "_iid", "_tid"]] = tcomments_parsed[["_cid", "_iid", "_tid"]].astype(int)
+    trace_with_nk = tcomments_parsed.merge(
+        tc_id_cols, left_on=["_cid", "_iid", "_tid"], right_on=["course_id", "instructor_id", "term_id"], how="inner"
+    )
+    trace_comment_counts = trace_with_nk.groupby("name_key").size()
+
+    # Combine
+    comment_counts_lookup = (rmp_comment_counts.add(trace_comment_counts, fill_value=0)).fillna(0).astype(int).to_dict()
+    print(f"Computed comment counts for {len(comment_counts_lookup)} professors")
+
     # ── Build catalog rows ──
     catalog_rows = []
     rmp_name_keys = set(rmp_profs["_name_key"].values)
@@ -448,6 +469,7 @@ def main():
             row.get("professor_url", None) or None,
             photo_lookup.get(row["_name_key"], None),
             avg_hours,
+            comment_counts_lookup.get(row["_name_key"], 0),
         ))
 
     # TRACE-only professors
@@ -474,6 +496,7 @@ def main():
             None, None, None,
             photo_lookup.get(nk, None),
             avg_hours_t,
+            comment_counts_lookup.get(nk, 0),
         ))
 
     print(f"Built catalog with {len(catalog_rows)} professors")
@@ -526,14 +549,15 @@ def main():
             difficulty FLOAT,
             professor_url TEXT,
             image_url TEXT,
-            avg_hours FLOAT
+            avg_hours FLOAT,
+            total_comments INT DEFAULT 0
         )
     """)
     chunk_insert(cur, """
         INSERT INTO professors_catalog
         (slug, name, name_key, department, college, avg_rating, rmp_rating, trace_rating,
          num_ratings, trace_reviews, total_reviews, would_take_again_pct, difficulty,
-         professor_url, image_url, avg_hours)
+         professor_url, image_url, avg_hours, total_comments)
         VALUES %s
     """, catalog_rows)
     cur.execute("CREATE INDEX idx_pc_name_key ON professors_catalog (name_key)")

--- a/backend/server.py
+++ b/backend/server.py
@@ -745,7 +745,17 @@ def professor_profile(slug):
                            CASE WHEN COALESCE(count_1,0)+COALESCE(count_2,0)+COALESCE(count_3,0)+COALESCE(count_4,0)+COALESCE(count_5,0) > 0
                                 THEN (COALESCE(count_1,0)+COALESCE(count_2,0)+COALESCE(count_3,0)+COALESCE(count_4,0)+COALESCE(count_5,0))::float
                                 ELSE CASE WHEN mean IS NOT NULL THEN 1.0 ELSE 0 END END
-                           ELSE 0 END)::float AS challeng_weight
+                           ELSE 0 END)::float AS challeng_weight,
+                       SUM(CASE WHEN LOWER(question) LIKE '%%overall%%' THEN
+                           CASE WHEN COALESCE(count_1,0)+COALESCE(count_2,0)+COALESCE(count_3,0)+COALESCE(count_4,0)+COALESCE(count_5,0) > 0
+                                THEN (1.0*COALESCE(count_1,0)::float+2.0*COALESCE(count_2,0)::float+3.0*COALESCE(count_3,0)::float+4.0*COALESCE(count_4,0)::float+5.0*COALESCE(count_5,0)::float)
+                                ELSE COALESCE(mean::float, 0) END
+                           ELSE 0 END)::float AS overall_sum,
+                       SUM(CASE WHEN LOWER(question) LIKE '%%overall%%' THEN
+                           CASE WHEN COALESCE(count_1,0)+COALESCE(count_2,0)+COALESCE(count_3,0)+COALESCE(count_4,0)+COALESCE(count_5,0) > 0
+                                THEN (COALESCE(count_1,0)+COALESCE(count_2,0)+COALESCE(count_3,0)+COALESCE(count_4,0)+COALESCE(count_5,0))::float
+                                ELSE CASE WHEN mean IS NOT NULL THEN 1.0 ELSE 0 END END
+                           ELSE 0 END)::float AS overall_weight
                 FROM trace_scores
                 WHERE (course_id, instructor_id, term_id) IN %s
                 GROUP BY course_id, instructor_id, term_id
@@ -796,11 +806,14 @@ def professor_profile(slug):
                 hs = float(agg["hours_sum"] or 0)
                 cw = float(agg["challeng_weight"] or 0)
                 cs = float(agg["challeng_sum"] or 0)
+                ow = float(agg["overall_weight"] or 0)
+                os_ = float(agg["overall_sum"] or 0)
                 challeng_sum += cs
                 challeng_weight += cw
             else:
-                hw, hs, cw, cs = 0, 0, 0, 0
+                hw, hs, cw, cs, ow, os_ = 0, 0, 0, 0, 0, 0
             course_hours = round(hs / hw, 1) if hw > 0 else None
+            course_overall = round(os_ / ow, 2) if ow > 0 else None
             trace_course_list.append({
                 "courseId": cid,
                 "termId": tid,
@@ -810,6 +823,7 @@ def professor_profile(slug):
                 "hoursPerWeek": course_hours,
                 "challengeWeightedSum": cs if cw > 0 else None,
                 "challengeResponses": cw if cw > 0 else None,
+                "overallRating": course_overall,
             })
 
         trace_avg_difficulty = round(challeng_sum / challeng_weight, 2) if challeng_weight > 0 else None

--- a/backend/server.py
+++ b/backend/server.py
@@ -1356,8 +1356,8 @@ def professors_catalog():
         # No search - use SQL sorting
         if sort == "rating":
             order = "avg_rating DESC NULLS LAST"
-        elif sort == "reviews":
-            order = "total_reviews DESC"
+        elif sort == "comments":
+            order = "total_comments DESC"
         else:
             order = "lower(name) ASC"
 
@@ -1373,32 +1373,6 @@ def professors_catalog():
             params + [limit, offset]
         )
 
-    # Batch-count RMP + TRACE comments for this page
-    comment_counts = {}
-    if page_rows:
-        name_keys = [row["name_key"] for row in page_rows]
-        placeholders = ",".join(["%s"] * len(name_keys))
-
-        combined_counts = query(
-            f"SELECT name_key, SUM(cnt) as cnt FROM ("
-            f"  SELECT name_key, COUNT(*) as cnt FROM rmp_reviews "
-            f"  WHERE name_key IN ({placeholders}) AND comment IS NOT NULL AND comment != '' "
-            f"  GROUP BY name_key"
-            f"  UNION ALL "
-            f"  SELECT tc2.name_key, COUNT(*) as cnt "
-            f"  FROM trace_comments tc "
-            f"  JOIN trace_courses tc2 ON tc.tc_course_id = tc2.course_id "
-            f"    AND tc.tc_instructor_id = tc2.instructor_id "
-            f"    AND tc.tc_term_id = tc2.term_id "
-            f"  WHERE tc2.name_key IN ({placeholders}) "
-            f"  AND tc.comment IS NOT NULL AND tc.comment != '' "
-            f"  GROUP BY tc2.name_key"
-            f") sub GROUP BY name_key",
-            name_keys + name_keys
-        )
-        for r in combined_counts:
-            comment_counts[r["name_key"]] = int(r["cnt"])
-
     professors = []
     for row in page_rows:
         professors.append({
@@ -1410,7 +1384,7 @@ def professors_catalog():
             "rmpRating": round(row["rmp_rating"], 2) if row["rmp_rating"] else None,
             "traceRating": round(row["trace_rating"], 2) if row["trace_rating"] else None,
             "totalReviews": row["total_reviews"],
-            "totalComments": comment_counts.get(row["name_key"], 0),
+            "totalComments": row.get("total_comments", 0) or 0,
             "wouldTakeAgainPct": round(row["would_take_again_pct"], 1) if row["would_take_again_pct"] else None,
             "imageUrl": row["image_url"],
         })

--- a/backend/server.py
+++ b/backend/server.py
@@ -177,7 +177,7 @@ BLOCKED_USER_AGENTS = [
 @app.before_request
 def block_bots():
     ua = (request.headers.get("User-Agent") or "").lower()
-    if not ua or any(bot in ua for bot in BLOCKED_USER_AGENTS):
+    if ua and any(bot in ua for bot in BLOCKED_USER_AGENTS):
         return jsonify({"error": "Forbidden"}), 403
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="robots" content="noindex, nofollow" />
+
+    <!-- Open Graph / Link Preview -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="RateMyHusky" />
+    <meta property="og:description" content="Course reviews and ratings by Northeastern students, for Northeastern students." />
+    <meta property="og:image" content="/logo.jpg" />
+    <meta property="og:url" content="https://ratemyhusky.com" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="RateMyHusky" />
+    <meta name="twitter:description" content="Course reviews and ratings by Northeastern students, for Northeastern students." />
+    <meta name="twitter:image" content="/logo.jpg" />
+
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
     <title>RateMyHusky</title>
   </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,20 +13,20 @@
     <link rel="icon" type="image/jpeg" href="/logo.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#ffffff" />
-    <meta name="robots" content="noindex, nofollow" />
+    <meta name="robots" content="index, follow" />
 
     <!-- Open Graph / Link Preview -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="RateMyHusky" />
-    <meta property="og:description" content="Course reviews and ratings by Northeastern students, for Northeastern students." />
-    <meta property="og:image" content="/logo.jpg" />
+    <meta property="og:description" content="Find the right professor, every semester. TRACE evaluations and RateMyProfessor ratings, all in one place." />
+    <meta property="og:image" content="https://ratemyhusky.com/logo.jpg" />
     <meta property="og:url" content="https://ratemyhusky.com" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="RateMyHusky" />
-    <meta name="twitter:description" content="Course reviews and ratings by Northeastern students, for Northeastern students." />
-    <meta name="twitter:image" content="/logo.jpg" />
+    <meta name="twitter:description" content="Find the right professor, every semester. TRACE evaluations and RateMyProfessor ratings, all in one place." />
+    <meta name="twitter:image" content="https://ratemyhusky.com/logo.jpg" />
 
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
     <title>RateMyHusky</title>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -274,7 +274,7 @@ export function fetchProfessorsCatalog(params: {
   maxRating?: number;
   minReviews?: number;
   maxReviews?: number;
-  sort?: 'alpha' | 'rating' | 'reviews';
+  sort?: 'alpha' | 'rating' | 'comments';
   page?: number;
   limit?: number;
 }): Promise<CatalogResponse> {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -39,6 +39,7 @@ export interface TraceCourse {
   hoursPerWeek?: number | null;
   challengeWeightedSum?: number | null;
   challengeResponses?: number | null;
+  overallRating?: number | null;
 }
 
 export interface TraceRatingCounts {

--- a/frontend/src/components/FeedbackTab.tsx
+++ b/frontend/src/components/FeedbackTab.tsx
@@ -14,7 +14,10 @@ declare global {
   }
 }
 
-const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'; // test key fallback
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+if (!TURNSTILE_SITE_KEY && import.meta.env.PROD) {
+  throw new Error('VITE_TURNSTILE_SITE_KEY environment variable is required in production');
+}
 
 const feedbackOptions = [
   { value: 'bug', label: 'Bug Report' },
@@ -43,7 +46,7 @@ const FeedbackTab = () => {
   }, []);
 
   const renderTurnstile = useCallback(() => {
-    if (!turnstileRef.current || !window.turnstile) return;
+    if (!turnstileRef.current || !window.turnstile || !TURNSTILE_SITE_KEY) return;
     if (widgetIdRef.current !== null) {
       window.turnstile.remove(widgetIdRef.current);
       widgetIdRef.current = null;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,3 +61,8 @@ img {
 html {
   background-color: #ffffff;
 }
+
+.husky-email {
+  font-weight: 700;
+  color: #d6394c;
+}

--- a/frontend/src/pages/Compare.css
+++ b/frontend/src/pages/Compare.css
@@ -441,7 +441,7 @@
 	font-weight: 800;
 	font-size: 0.72rem;
 	color: #7b7b7b;
-	word-break: keep-all;
+	word-break: break-word;
 }
 
 .compare-lock-icon {

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -525,12 +525,12 @@ function Compare() {
 				? `${leftSnapshot.score.toFixed(2)} (${leftSnapshot.term})`
 				: user
 					? 'N/A'
-					: 'Sign in to view',
+					: 'Sign in to view TRACE',
 			right: rightSnapshot
 				? `${rightSnapshot.score.toFixed(2)} (${rightSnapshot.term})`
 				: user
 					? 'N/A'
-					: 'Sign in to view',
+					: 'Sign in to view TRACE',
 			footnoteLeft: leftSnapshot?.course,
 			footnoteRight: rightSnapshot?.course,
 			winner: pickWinner(leftSnapshot?.score, rightSnapshot?.score),
@@ -796,14 +796,14 @@ function Compare() {
 						const showLeft = Boolean(leftSlug) && !leftLoading;
 						const showRight = Boolean(rightSlug) && !rightLoading;
 						const renderValue = (value: string, showValue: boolean) => {
-							if (!authLoading && showValue && row.label === 'Recent TRACE Snapshot' && value === 'Sign in to view') {
+							if (!authLoading && showValue && row.label === 'Recent TRACE Snapshot' && value === 'Sign in to view TRACE') {
 								return (
 									<span className="compare-lock-prompt">
 										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="compare-lock-icon">
 											<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
 											<path d="M7 11V7a5 5 0 0 1 10 0v4" />
 										</svg>
-										<span>Sign in to view</span>
+										<span>Sign in with your husky.neu.edu account to view</span>
 									</span>
 								);
 							}

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -43,7 +43,7 @@ const parseMaybeNumber = (value: number | null | undefined) => {
 
 const formatMetric = (value: number | null | undefined, digits = 2) => {
 	const parsed = parseMaybeNumber(value);
-	return parsed === null ? 'N/A' : parsed.toFixed(digits);
+	return parsed === null ? '—' : parsed.toFixed(digits);
 };
 
 const getDifficultyClass = (value: number | null | undefined) => {
@@ -454,12 +454,12 @@ function Compare() {
 		? `${leftCatalogProfessor.department} (${leftCatalogProfessor.college})`
 		: leftProfile?.department
 			? leftProfile.department
-			: 'N/A';
+			: '—';
 	const rightDept = rightCatalogProfessor
 		? `${rightCatalogProfessor.department} (${rightCatalogProfessor.college})`
 		: rightProfile?.department
 			? rightProfile.department
-			: 'N/A';
+			: '—';
 
 	const compareRows = [
 		{
@@ -501,8 +501,8 @@ function Compare() {
 		},
 		{
 			label: 'Total Reviews',
-			left: leftProfile?.totalComments?.toLocaleString() ?? leftCatalogProfessor?.totalComments?.toLocaleString() ?? 'N/A',
-			right: rightProfile?.totalComments?.toLocaleString() ?? rightCatalogProfessor?.totalComments?.toLocaleString() ?? 'N/A',
+			left: leftProfile?.totalComments?.toLocaleString() ?? leftCatalogProfessor?.totalComments?.toLocaleString() ?? '—',
+			right: rightProfile?.totalComments?.toLocaleString() ?? rightCatalogProfessor?.totalComments?.toLocaleString() ?? '—',
 			winner: pickWinner(leftProfile?.totalComments ?? leftCatalogProfessor?.totalComments, rightProfile?.totalComments ?? rightCatalogProfessor?.totalComments, 'higher', 0),
 			weight: 0.5,
 		},
@@ -510,11 +510,11 @@ function Compare() {
 			label: 'Would Take Again',
 			left:
 				leftProfile?.wouldTakeAgainPct === null || leftProfile?.wouldTakeAgainPct === undefined
-					? 'N/A'
+					? '—'
 					: `${leftProfile.wouldTakeAgainPct.toFixed(0)}%`,
 			right:
 				rightProfile?.wouldTakeAgainPct === null || rightProfile?.wouldTakeAgainPct === undefined
-					? 'N/A'
+					? '—'
 					: `${rightProfile.wouldTakeAgainPct.toFixed(0)}%`,
 			winner: pickWinner(leftProfile?.wouldTakeAgainPct, rightProfile?.wouldTakeAgainPct, 'higher', 0),
 			weight: 2,
@@ -524,12 +524,12 @@ function Compare() {
 			left: leftSnapshot
 				? `${leftSnapshot.score.toFixed(2)} (${leftSnapshot.term})`
 				: user
-					? 'N/A'
+					? '—'
 					: 'Sign in to view TRACE',
 			right: rightSnapshot
 				? `${rightSnapshot.score.toFixed(2)} (${rightSnapshot.term})`
 				: user
-					? 'N/A'
+					? '—'
 					: 'Sign in to view TRACE',
 			footnoteLeft: leftSnapshot?.course,
 			footnoteRight: rightSnapshot?.course,
@@ -700,7 +700,7 @@ function Compare() {
 									>
 										<span className="compare-suggestion-main">{prof.name}</span>
 										<span className="compare-suggestion-meta">
-											{prof.dept} • {prof.rating !== null ? prof.rating.toFixed(2) : 'N/A'}
+											{prof.dept} • {prof.rating !== null ? prof.rating.toFixed(2) : '—'}
 										</span>
 									</button>
 								);
@@ -763,7 +763,7 @@ function Compare() {
 									>
 										<span className="compare-suggestion-main">{prof.name}</span>
 										<span className="compare-suggestion-meta">
-											{prof.dept} • {prof.rating !== null ? prof.rating.toFixed(2) : 'N/A'}
+											{prof.dept} • {prof.rating !== null ? prof.rating.toFixed(2) : '—'}
 										</span>
 									</button>
 								);

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -803,7 +803,7 @@ function Compare() {
 											<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
 											<path d="M7 11V7a5 5 0 0 1 10 0v4" />
 										</svg>
-										<span>Sign in with your husky.neu.edu account to view</span>
+										<span>Sign in with your <span className="husky-email">husky.neu.edu</span> account to view</span>
 									</span>
 								);
 							}

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -80,19 +80,22 @@ const pickWinner = (
 const cleanTermTitle = (t: string): string => t.replace(/^\d{6}:\s*/, '').replace(/\s*\d{6}/g, '').trim();
 
 const getRecentTraceSnapshot = (profile: ProfessorProfile | null): TraceSnapshot | null => {
-	if (!profile?.traceCourses?.length || profile.traceRating == null) return null;
+	if (!profile?.traceCourses?.length) return null;
 
-	const mostRecent = [...profile.traceCourses].sort((a, b) => {
+	const sorted = [...profile.traceCourses].sort((a, b) => {
 		const ka = termSortKey(a.termTitle);
 		const kb = termSortKey(b.termTitle);
 		if (ka !== kb) return kb - ka;
 		return b.courseId - a.courseId;
-	})[0];
+	});
+
+	const mostRecent = sorted.find((c) => c.overallRating != null);
+	if (!mostRecent || mostRecent.overallRating == null) return null;
 
 	return {
 		term: cleanTermTitle(mostRecent.termTitle),
 		course: mostRecent.displayName,
-		score: profile.traceRating,
+		score: mostRecent.overallRating,
 	};
 };
 

--- a/frontend/src/pages/Course.tsx
+++ b/frontend/src/pages/Course.tsx
@@ -293,7 +293,7 @@ const Course = () => {
 								<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
 								<path d="M7 11V7a5 5 0 0 1 10 0v4" />
 							</svg>
-							<p>Sign in with your <strong>husky.neu.edu</strong> account to view historical rating trends.</p>
+							<p>Sign in with your <span className="husky-email">husky.neu.edu</span> account to view historical rating trends.</p>
 							<button className="paywall-signin-btn" onClick={() => setShowSignIn(true)}>Sign In</button>
 						</div>
 					) : (

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -805,7 +805,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
           )}
         </div>
         <div className="prof-stat-card">
-          <span className="prof-stat-value">{stats.difficulty > 0 ? <AnimatedNumber value={stats.difficulty} /> : '—'}</span>
+          <span className="prof-stat-value">{stats.difficulty != null && stats.difficulty > 0 ? <AnimatedNumber value={stats.difficulty} /> : '—'}</span>
           <span className="prof-stat-label">Difficulty</span>
           <div className="prof-difficulty-bar">
             <div className="prof-difficulty-fill" style={{ 
@@ -835,7 +835,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
           <span className="prof-stat-label">Hrs / Week</span>
         </div>
         <div className="prof-stat-card prof-stat-clickable" onClick={() => chartsRef.current?.scrollIntoView({ behavior: 'smooth' })}>
-          <span className="prof-stat-value">{stats.totalRatings !== null ? stats.totalRatings.toLocaleString() : '—'}</span>
+          <span className="prof-stat-value">{stats.totalRatings ? stats.totalRatings.toLocaleString() : '—'}</span>
           <span className="prof-stat-label">Total Ratings</span>
           <span className="prof-stat-hint">View distribution ↓</span>
         </div>

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -451,11 +451,11 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
 
     if (noneSelected) {
       return {
-        avgRating: 0,
+        avgRating: null,
         rmpRating: null,
         traceRating: null,
-        difficulty: 0,
-        totalRatings: 0,
+        difficulty: null,
+        totalRatings: null,
         wouldTakeAgainPct: profile.wouldTakeAgainPct,
         hoursPerWeek: null,
       };
@@ -789,7 +789,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
 
       <section className="prof-stats">
         <div className="prof-stat-card prof-stat-clickable">
-          <span className="prof-stat-value"><AnimatedNumber value={stats.avgRating} /></span>
+          <span className="prof-stat-value">{stats.avgRating !== null ? <AnimatedNumber value={stats.avgRating} /> : '—'}</span>
           <span className="prof-stat-label" style={{ display: 'block', textAlign: 'center', position: 'relative' }}>
             Overall Rating
             {(stats.rmpRating !== null || stats.traceRating !== null) && (
@@ -835,7 +835,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
           <span className="prof-stat-label">Hrs / Week</span>
         </div>
         <div className="prof-stat-card prof-stat-clickable" onClick={() => chartsRef.current?.scrollIntoView({ behavior: 'smooth' })}>
-          <span className="prof-stat-value">{stats.totalRatings.toLocaleString()}</span>
+          <span className="prof-stat-value">{stats.totalRatings !== null ? stats.totalRatings.toLocaleString() : '—'}</span>
           <span className="prof-stat-label">Total Ratings</span>
           <span className="prof-stat-hint">View distribution ↓</span>
         </div>

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -462,12 +462,15 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
     }
 
     if (allSelected) {
+      const traceCompleted = profile.traceRatingCounts
+        ? Object.values(profile.traceRatingCounts).reduce((sum, rc) => sum + (rc.completed || 0), 0)
+        : 0;
       return {
         avgRating: profile.avgRating,
         rmpRating: profile.rmpRating,
         traceRating: profile.traceRating,
         difficulty: profile.difficulty ?? 0,
-        totalRatings: profile.totalRatings,
+        totalRatings: filteredRmpReviews.length + traceCompleted,
         wouldTakeAgainPct: profile.wouldTakeAgainPct,
         hoursPerWeek: profile.hoursPerWeek,
       };

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -897,7 +897,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
               <path d="M7 11V7a5 5 0 0 1 10 0v4" />
             </svg>
-            <p>Sign in with your <strong>husky.neu.edu</strong> account to view the full radar breakdown.</p>
+            <p>Sign in with your <span className="husky-email">husky.neu.edu</span> account to view the full radar breakdown.</p>
             <button className="paywall-signin-btn" onClick={() => { sessionStorage.setItem('prof_review_tab', 'trace'); setShowSignIn(true); }}>Sign In</button>
           </div>
         </section>
@@ -1381,7 +1381,7 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
                           <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                           <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                         </svg>
-                        <p>Sign in with your <strong>husky.neu.edu</strong> account to read these comments.</p>
+                        <p>Sign in with your <span className="husky-email">husky.neu.edu</span> account to read these comments.</p>
                         <button className="paywall-signin-btn small" onClick={(e) => { e.stopPropagation(); sessionStorage.setItem('prof_review_tab', 'trace'); setShowSignIn(true); }}>Sign In</button>
                       </div>
                     )}

--- a/frontend/src/pages/Professor.tsx
+++ b/frontend/src/pages/Professor.tsx
@@ -462,15 +462,12 @@ const [showCourseTip, setShowCourseTip] = useState(() => localStorage.getItem('p
     }
 
     if (allSelected) {
-      const traceCompleted = profile.traceRatingCounts
-        ? Object.values(profile.traceRatingCounts).reduce((sum, rc) => sum + (rc.completed || 0), 0)
-        : 0;
       return {
         avgRating: profile.avgRating,
         rmpRating: profile.rmpRating,
         traceRating: profile.traceRating,
         difficulty: profile.difficulty ?? 0,
-        totalRatings: profile.totalRatings + traceCompleted,
+        totalRatings: profile.totalRatings,
         wouldTakeAgainPct: profile.wouldTakeAgainPct,
         hoursPerWeek: profile.hoursPerWeek,
       };

--- a/frontend/src/pages/ProfessorCatalog.tsx
+++ b/frontend/src/pages/ProfessorCatalog.tsx
@@ -17,7 +17,7 @@ import './ProfessorCatalog.css';
 const SORT_OPTIONS = [
   { value: 'alpha',   label: 'A – Z' },
   { value: 'rating',  label: 'Highest Rating' },
-  { value: 'reviews', label: 'Most Reviews' },
+  { value: 'comments', label: 'Most Comments' },
 ];
 
 const REVIEW_SLIDER_MAX = 1000;
@@ -49,7 +49,7 @@ const DEFAULT_FILTERS: Filters = {
 
 function getFiltersFromSearchParams(sp: URLSearchParams): Filters {
   const sortValue = sp.get('sort');
-  const sort = sortValue === 'rating' || sortValue === 'reviews' || sortValue === 'alpha'
+  const sort = sortValue === 'rating' || sortValue === 'comments' || sortValue === 'alpha'
     ? sortValue
     : 'alpha';
 
@@ -197,7 +197,7 @@ export default function ProfessorCatalog() {
       maxRating:  filters.maxRating  < 5 ? filters.maxRating  : undefined,
       minReviews: filters.minReviews > 0 ? filters.minReviews : undefined,
       maxReviews: filters.maxReviews ?? undefined,
-      sort:       filters.sort as 'alpha' | 'rating' | 'reviews',
+      sort:       filters.sort as 'alpha' | 'rating' | 'comments',
       page:       filters.page,
       limit:      pageSize,
     })


### PR DESCRIPTION
This pull request introduces several backend and frontend improvements focused on professor catalog data, especially around comment counts, data accuracy, and user experience. The main changes include adding a precomputed total comment count for each professor, improving catalog and comparison sorting, enhancing meta tags for SEO and sharing, and refining the user interface for clarity.

**Backend Data Improvements:**

- Added precomputation of total comment counts (from both RMP and TRACE) per professor, storing the result in the `professors_catalog` table as a new `total_comments` column for faster and more accurate lookups and sorting. The API and SQL queries were updated to use this field instead of recomputing counts on the fly. [[1]](diffhunk://#diff-ed6b62c8ea18a1098939f865bdd12b4e346648917597181d226d738ab5520e88R393-R413) [[2]](diffhunk://#diff-ed6b62c8ea18a1098939f865bdd12b4e346648917597181d226d738ab5520e88R472) [[3]](diffhunk://#diff-ed6b62c8ea18a1098939f865bdd12b4e346648917597181d226d738ab5520e88R499) [[4]](diffhunk://#diff-ed6b62c8ea18a1098939f865bdd12b4e346648917597181d226d738ab5520e88L529-R560) [[5]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edL1345-R1360) [[6]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edL1362-L1387) [[7]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edL1399-R1387)

- Improved the TRACE course aggregation in the professor profile endpoint to include an `overallRating` per course, and exposed this field in the API for use in the frontend. [[1]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edL748-R758) [[2]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edR809-R816) [[3]](diffhunk://#diff-7aad1d8a7c12e554a56640e331270f5fc84e24f6f937b35b69eb83766b2318edR826) [[4]](diffhunk://#diff-9099dfcb65b652e332f3cf44e249de1a3272067a71f96d8c059b4a7ba77b01ebR42)

**Frontend and API Enhancements:**

- Updated the catalog and comparison pages to use the new `totalComments` field and allow sorting by comment count (renamed from "reviews" to "comments" in API and UI). [[1]](diffhunk://#diff-9099dfcb65b652e332f3cf44e249de1a3272067a71f96d8c059b4a7ba77b01ebL276-R277) [[2]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L501-R517)

- Refined the display of missing or unavailable data in the comparison UI, replacing "N/A" with "—" for consistency and clarity. [[1]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L46-R46) [[2]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L454-R462) [[3]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L501-R517) [[4]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L524-R533) [[5]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L700-R703) [[6]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L763-R766)

- The "Recent TRACE Snapshot" in comparisons now uses the most recent course with an available `overallRating` instead of falling back to the professor's average.

**SEO and Sharing Improvements:**

- Changed the site's robots meta tag to allow indexing and following, and added Open Graph and Twitter meta tags for better link previews and social sharing.

**Other Fixes and Enhancements:**

- Improved bot detection logic in the backend to avoid blocking users with empty user agents.

- Enforced that the Turnstile site key must be present in production, improving security and error handling for the feedback component. [[1]](diffhunk://#diff-0d160fc14d8441ca7d09a6458339fd168dacf2df20433f955736f4be77ebc11bL17-R20) [[2]](diffhunk://#diff-0d160fc14d8441ca7d09a6458339fd168dacf2df20433f955736f4be77ebc11bL46-R49)

- Minor UI tweaks, such as improved word-breaking in compare tables and styling for Husky email prompts. [[1]](diffhunk://#diff-0a70980d1a171cc0131539cacf869fa118673c5a7e648ccf97f5a675ce92f432L444-R444) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R64-R68) [[3]](diffhunk://#diff-0a82aa9abe0f60d0f25f94d6886f8e8f86a1ccc698baef2c540b9b0941d5f4c0L796-R806)